### PR TITLE
feat: extended preview settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ To be able to communicate with a local LLM and use this plugin, you need a runni
 |---|---|---|
 |Action keyword|ol|Keyword to activate the plugin.|
 |Ollama Host|http://localhost:11434|URL of the local Ollama instance to communicate via API.|
-|Ollama Model|gemma:2b|The LLM to be used ([Ollama model library](https://ollama.com/library)).|
+|Ollama Model|llama3.2:1b|The LLM to be used ([Ollama model library](https://ollama.com/library)).|
 |Automatic Model Download|[ ] - *false*|Download LLM automatically if not already installed.<br>*Be careful - the download may take some time and storage on your disk*.|
 |Save Chat to File|[x] - *true*|Should the chat be saved as a text file? This allows it to be opened directly in a text editor.|
+|Chat preview preserve newline|[ ] - *false*|Should the chat preview retain the line breaks or output them as continuous text.<br>If true, the heading 'Copy Response to Clipboard' can be moved outside the visible area. However the text is still always copied to the clipboard with the correct formatting.|
+|Chat preview length|100|Length of the chat preview, freely selectable.|
 |Prompt Stop|&#124;&#124;|Characters to indicate end of prompt. This saves computing time, as otherwise the LLM is executed every time a key is pressed.|
 |Log Level|ERROR|The Log Level can be adjusted for error analysis. Normally not of interest for users.|

--- a/SettingsTemplate.yaml
+++ b/SettingsTemplate.yaml
@@ -9,20 +9,32 @@ body:
     attributes:
       name: ollama_model
       label: "Ollama Model:"
-      defaultValue: "gemma:2b"
-      description: "The LLM to be used (model library https://ollama.com/library). Default - gemma:2b"
+      defaultValue: "llama3.2:1b"
+      description: "The LLM to be used (model library https://ollama.com/library). Default - llama3.2:1b"
   - type: checkbox
     attributes:
       name: pull_model
-      label: "Automatic Model Download"
+      label: "Automatic Model Download:"
       description: "Download LLM automatically if not already installed?"
       defaultValue: 'false'
   - type: checkbox
     attributes:
       name: save_response
-      label: "Save Chat to File"
+      label: "Save Chat to File:"
       description: "Should the chat be saved as a text file? This allows it to be opened directly in a text editor."
       defaultValue: 'true'
+  - type: checkbox
+    attributes:
+      name: preserve_newline
+      label: "Chat preview preserve newline:"
+      description: "Should the chat preview retain the line breaks or output them as continuous text. \nIf true, the heading 'Copy Response to Clipboard' can be moved outside the visible area. However the text is still always copied to the clipboard with the correct formatting."
+      defaultValue: 'false'
+  - type: input
+    attributes:
+      name: response_preview_length
+      label: "Chat preview length:"
+      defaultValue: "100"
+      description: "Length of the chat preview, freely selectable. Default - 100 characters"
   - type: input
     attributes:
       name: prompt_stop

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Ollama",
     "Description": "Plugin to use Ollama for local LLMs in Flow Launcher",
     "Author": "Gh0stExp10it",
-    "Version": "1.0.4",
+    "Version": "1.0.5",
     "Language": "python",
     "Website": "https://github.com/Gh0stExp10it/Flow.Launcher.Plugin.Ollama",
     "IcoPath": "Images\\app.png",

--- a/plugin/ollama.py
+++ b/plugin/ollama.py
@@ -67,7 +67,7 @@ class Ollama:
 
         Args:
             * self (object): Reference to the current object instance.
-            * message (str, optional): The message to send to the model. Defaults to "Whats 1 plus 1?".
+            * query (str, optional): The message to send to the model. Defaults to "Whats 1 plus 1?".
 
         Returns:
             * str: The response content from the model, or None if an error occurs.
@@ -86,26 +86,28 @@ class Ollama:
         except OllamaResponseError as e:
                 logging.error(f"Error: <{e.status_code}> - {e.error}")
 
-    def shorten(self, string: str, length: int):
+    def shorten(self, string: str, length: int, preserve_newline: bool = False) -> str:
         """
-        Shortens a string and adds an ellipsis (...) if it exceeds a specified length.
+        Shortens a string and appends "..." if it exceeds a specified length.
+        Provides an option to preserve or replace newlines with spaces.
 
         Args:
             * self (object): Reference to the current object instance.
-            * string: The string to be shortened.
-            * length: The maximum desired length of the output string.
+            * string (str): The string to be shortened.
+            * length (int): The maximum desired length of the output string.
+            * preserve_newlines (bool): If True, preserves newlines. If False, replaces them with spaces.
 
         Returns:
-            * str: The shortened string with an ellipsis
+            str: The shortened string with "...".
         """
-        string = string.split("\n", 1)[0]
+
+        if not preserve_newline:
+            string = string.replace("\n", " ")
 
         if len(string) > length:
-            shortened_string = string[:length - 3] + "..."
+            return string[:length - 3] + "..."
         else:
-            shortened_string = string
-
-        return shortened_string
+            return string
 
     def save_file(self, query: str, response: str, timestamp: datetime, duration: int) -> str:
         """

--- a/plugin/query.py
+++ b/plugin/query.py
@@ -14,6 +14,8 @@ class Query(Method):
         self.prompt_stop = self.plugin.settings.get("prompt_stop")
         self.save_response = self.plugin.settings.get("save_response")
         self.log_level = self.plugin.settings.get("log_level")
+        self.preserve_newline = self.plugin.settings.get("preserve_newline")
+        self.response_preview_length = self.plugin.settings.get("response_preview_length")
 
         if self.log_level:
             self.plugin._logger.setLevel(self.log_level)
@@ -33,7 +35,7 @@ class Query(Method):
                         chat_response, chat_duration = ollama_client.chat(query=query[:-len(self.prompt_stop)])
                         
                         title_clipboard = f"Copy Response to Clipboard"
-                        message_clipboard = f"{ollama_client.shorten(string=chat_response, length=30)}"
+                        message_clipboard = f"{ollama_client.shorten(string=chat_response, length=int(self.response_preview_length), preserve_newline=self.preserve_newline)}"
                         json_rpc_action_clipboard = API.copy_to_clipboard(text=chat_response)
                     else:
                         title_clipboard = f"ERROR"
@@ -55,7 +57,7 @@ class Query(Method):
                         json_rpc_action_file = API.shell_run(command=f"start {absolute_filename}",
                                                              filename= "cmd.exe")
                     else:
-                        title_file = f"ERROR"
+                        title_file = f"Open Chat in Editor [DISABLED]"
                         message_file = f"Error: Can't write and open file - please check your configuration!"
                         json_rpc_action_file = API.open_url(self.plugin.manifest().get("Website"))
                     


### PR DESCRIPTION
closes #14

Extended functionality for the preview area of Flow-Launcher. Two new setting parameters have been added to give the user complete control:
- Chat preview length:
   - Number/Integer
   - Length of the chat preview, freely selectable. Default - 100 characters
- Chat preview preserve newline:
   - Boolean (True or False)
   - Should the chat preview retain the line breaks or output them as continuous text. If true, the heading 'Copy Response to Clipboard' can be moved outside the visible area. However the text is still always copied to the clipboard with the correct formatting.

Unfortunately, the preview functionality of Flow-Launcher is currently limited to the display of images (unless Quicklook is used as an external plugin). The only solution is to extend the variable ```SubTitle``` so that it displays the chat response of the LLM in an extended or even complete form. This is also associated with a restriction: New lines in the Markdown formatting mean that the extended ```SubTitle``` moves the ```Title``` with description of the actual ‘Copy Response to Clipboard’ functionality. If you can live with this, set the new parameter ‘Chat preview preserve newline’ to ```True```. If the parameter is set to ```False```, line breaks are replaced by spaces.

---

![FlowLauncher_Ollama_NewSettings](https://github.com/user-attachments/assets/fafbd171-5a9f-4d8e-b973-1435de3465f5)
New Settings

![FlowLauncher_Ollama_1000Chars_ReplaceNewline](https://github.com/user-attachments/assets/b8f47b7e-d472-4bfb-b5ff-af65412cc8f6)
Example - replace newline (Chat preview preserve newline == False)

![FlowLauncher_Ollama_1000Chars_PreserveNewline](https://github.com/user-attachments/assets/b47ef819-b57f-4d32-b573-0da2fad33a0e)
Example - preserve newline (Chat preview preserve newline == True)