### PR TITLE
feat: implement option to disable chain-of-thought (CoT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flow Launcher Plugin - Ollama
-This Flow Launcher Plugin allows you to interact with a local Ollama instance and your favorite and private LLMs (e.g. Llama 3, Gemma 2, Phi-3, TinyLlama, ...). It provides a convenient way to access the power of these language models directly from Flow Launcher.
+This Flow Launcher Plugin allows you to interact with a local Ollama instance and your favorite and private LLMs (e.g. Llama 3, Gemma 3, Phi-4, DeepSeek-R1, TinyLlama, ...). It provides a convenient way to access the power of these language models directly from Flow Launcher.
 The plugin offers two interaction options, copying the answer directly to the clipboard and writing the conversation (question + response) to a text file, which can be opened directly via the plugin.
 
 ![Plugin Example](./Images/plugin-example.gif)
@@ -55,6 +55,7 @@ To be able to communicate with a local LLM and use this plugin, you need a runni
 |Ollama Model|llama3.2:1b|The LLM to be used ([Ollama model library](https://ollama.com/library)).|
 |Automatic Model Download|[ ] - *false*|Download LLM automatically if not already installed.<br>*Be careful - the download may take some time and storage on your disk*.|
 |Save Chat to File|[x] - *true*|Should the chat be saved as a text file? This allows it to be opened directly in a text editor.|
+|Enable CoT (Chain-of-Thought)|[x] - *true*|Enable or disable the Chain-of-Thought reasoning for supported models (e.g. DeepSeek-R1).<br>Disabling this option will remove the \<think> tag and suppress intermediate reasoning steps.|
 |Chat preview preserve newline|[ ] - *false*|Should the chat preview retain the line breaks or output them as continuous text.<br>If true, the heading 'Copy Response to Clipboard' can be moved outside the visible area. However the text is still always copied to the clipboard with the correct formatting. [View an example](#example)|
 |Chat preview length|100|Length of the chat preview, freely selectable. [View an example](#example)|
 |Prompt Stop|&#124;&#124;|Characters to indicate end of prompt. This saves computing time, as otherwise the LLM is executed every time a key is pressed.|

--- a/SettingsTemplate.yaml
+++ b/SettingsTemplate.yaml
@@ -25,6 +25,12 @@ body:
       defaultValue: 'true'
   - type: checkbox
     attributes:
+      name: enable_cot
+      label: "Enable CoT (Chain-of-Thought):"
+      description: "Enable or disable the Chain-of-Thought reasoning for supported models (e.g. DeepSeek-R1). \nDisabling this option will remove the <think> tag and suppress intermediate reasoning steps."
+      defaultValue: 'true'
+  - type: checkbox
+    attributes:
       name: preserve_newline
       label: "Chat preview preserve newline:"
       description: "Should the chat preview retain the line breaks or output them as continuous text. \nIf true, the heading 'Copy Response to Clipboard' can be moved outside the visible area. However the text is still always copied to the clipboard with the correct formatting."

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Ollama",
     "Description": "Plugin to use Ollama for local LLMs in Flow Launcher",
     "Author": "Gh0stExp10it",
-    "Version": "1.1.0",
+    "Version": "1.1.1",
     "Language": "python",
     "Website": "https://github.com/Gh0stExp10it/Flow.Launcher.Plugin.Ollama",
     "IcoPath": "Images\\app.png",

--- a/plugin/ollama.py
+++ b/plugin/ollama.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from datetime import datetime, timedelta
 from ollama import Client as OllamaClient, ChatResponse as OllamaChatResponse, ResponseError as OllamaResponseError
 
@@ -29,7 +30,7 @@ class Ollama:
             self.ollama_client = OllamaClient(host=self.ollama_host)
             self.initialized = True
             logging.info("Ollama-Client initialized.")
-        
+
     def check_model(self, pull_model: bool) -> bool:
         """
         Checks if the specified Ollama model exists and attempts to download it if not.
@@ -61,7 +62,7 @@ class Ollama:
             else:
                 return False
     
-    def chat(self, query: str) -> tuple[str, int]:
+    def chat(self, query: str, enable_cot: bool = True) -> tuple[str, int]:
         """
         Sends the requested chat message to the Ollama model and retrieves the response.
 
@@ -163,3 +164,26 @@ class Ollama:
             logging.error(PermissionError)
         
         return absolute_filename
+    
+    def remove_cot(self, string: str) -> str:
+        """
+        Removes the CoT (Chain-of-Thought) reasoning for supported models in post-processing.
+        This option will remove the <think> tag and suppress intermediate reasoning steps.
+
+        Args:
+            * self (object): Reference to the current object instance.
+            * string (str): The string/response with CoT to be cleaned.
+
+        Returns:
+            str: The cleaned string/response withouth CoT.
+        """
+
+        # Regex pattern: Match <think> and </think> including content and ensures that '.' matches newlines as well
+        if "<think>" in string and "</think>" in string:
+            string = re.sub(pattern=r"<think>.*?</think>",
+                            repl="",
+                            string=string,
+                            flags=re.DOTALL
+                        ).strip()
+        
+        return string

--- a/plugin/ollama.py
+++ b/plugin/ollama.py
@@ -62,7 +62,7 @@ class Ollama:
             else:
                 return False
     
-    def chat(self, query: str, enable_cot: bool = True) -> tuple[str, int]:
+    def chat(self, query: str) -> tuple[str, int]:
         """
         Sends the requested chat message to the Ollama model and retrieves the response.
 

--- a/plugin/query.py
+++ b/plugin/query.py
@@ -16,6 +16,7 @@ class Query(Method):
         self.log_level = self.plugin.settings.get("log_level")
         self.preserve_newline = self.plugin.settings.get("preserve_newline")
         self.response_preview_length = self.plugin.settings.get("response_preview_length")
+        self.enable_cot = self.plugin.settings.get("enable_cot")
 
         if self.log_level:
             self.plugin._logger.setLevel(self.log_level)
@@ -33,6 +34,9 @@ class Query(Method):
                     if model_exists:                      
                         # Send query to Ollama and ensure that the prompt_stop characters are removed
                         chat_response, chat_duration = ollama_client.chat(query=query[:-len(self.prompt_stop)])
+                        
+                        if not self.enable_cot:
+                            chat_response = ollama_client.remove_cot(string=chat_response)
                         
                         title_clipboard = f"Copy Response to Clipboard"
                         message_clipboard = f"{ollama_client.shorten(string=chat_response, length=int(self.response_preview_length), preserve_newline=self.preserve_newline)}"


### PR DESCRIPTION
This feature provides the user a option to enable or disable the Chain-of-Thoughts (CoT) of reasoning models like DeepSeek-R1 via a checkbox. This option provides a post processing of the given \<think> tag (regex), it does not manipulate any model parameters or enables a custom model configuration. By default the CoT is enabled.

---

Closes #33 